### PR TITLE
fix: `choco list` command is now local only

### DIFF
--- a/source/Intune-Win32-Deployer.ps1
+++ b/source/Intune-Win32-Deployer.ps1
@@ -293,7 +293,7 @@ function Create-winget4Dependency {
 
 function CheckInstall-LocalChocolatey{
     # Check if chocolatey is installed
-    $CheckChocolatey = C:\ProgramData\chocolatey\choco.exe list --localonly
+    $CheckChocolatey = C:\ProgramData\chocolatey\choco.exe list
     if (!$CheckChocolatey){
         Write-Host "Instaling Chocolatey (on local machine)"
         Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))

--- a/source/apps-custom/Chocolatey Updater/install.ps1
+++ b/source/apps-custom/Chocolatey Updater/install.ps1
@@ -4,7 +4,7 @@ $Path_4netIntune = "$Env:Programfiles\4net\EndpointManager"
 Start-Transcript -Path "$Path_4netIntune\Log\$PackageName-install.log" -Force
 
 # Check choco.exe 
-$localprograms = C:\ProgramData\chocolatey\choco.exe list --localonly
+$localprograms = C:\ProgramData\chocolatey\choco.exe list
 if ($localprograms -like "*Chocolatey*"){
     Write-Host "Chocolatey installed"
 }else{

--- a/source/apps-custom/Chocolatey/check.ps1
+++ b/source/apps-custom/Chocolatey/check.ps1
@@ -1,6 +1,6 @@
 $ProgramName = "Chocolatey"
 
-$localprograms = C:\ProgramData\chocolatey\choco.exe list --localonly
+$localprograms = C:\ProgramData\chocolatey\choco.exe list
 if ($localprograms -like "*$ProgramName*"){
     Write-Host "Found it!"
 }else{

--- a/source/apps-custom/Chocolatey/install.ps1
+++ b/source/apps-custom/Chocolatey/install.ps1
@@ -8,7 +8,7 @@ try{
         Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
     }
 
-    C:\ProgramData\chocolatey\choco.exe list -lo
+    C:\ProgramData\chocolatey\choco.exe list
 
     choco feature enable -n=useRememberedArgumentsForUpgrades
     

--- a/source/ressources/prerequirements_AsAdmin.ps1
+++ b/source/ressources/prerequirements_AsAdmin.ps1
@@ -31,7 +31,7 @@ If (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]:
 
 if($choco -eq $true){
     # Check if chocolatey is installed
-    $Check_Chocolatey = try{C:\ProgramData\chocolatey\choco.exe list --localonly}catch{}
+    $Check_Chocolatey = try{C:\ProgramData\chocolatey\choco.exe list}catch{}
     if (!$Check_Chocolatey){
         try{
             Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1')) 

--- a/source/ressources/template/choco/check.ps1
+++ b/source/ressources/template/choco/check.ps1
@@ -1,7 +1,7 @@
 $ProgramName = "CHOCOPROGRAMID"
 
 
-$ChocoPrg_Existing = C:\ProgramData\chocolatey\choco.exe list --localonly
+$ChocoPrg_Existing = C:\ProgramData\chocolatey\choco.exe list
     if ($ChocoPrg_Existing -like "*$ProgramName*"){
     Write-Host "Found it!"
 }

--- a/source/ressources/template/choco/install.ps1
+++ b/source/ressources/template/choco/install.ps1
@@ -2,7 +2,7 @@
 $Path_4Log = "$Env:Programfiles\_MEM"
 Start-Transcript -Path "$Path_4Log\Log\$ProgramName-install.log" -Force
 
-$localprograms = C:\ProgramData\chocolatey\choco.exe list --localonly
+$localprograms = C:\ProgramData\chocolatey\choco.exe list
 if ($localprograms -like "*$ProgramName*"){
     C:\ProgramData\chocolatey\choco.exe upgrade $ProgramName -y
 }else{


### PR DESCRIPTION
Since Chocolatey 2.0.0, `choco list` command is local only by default. Therefor, 'localonly' and 'lo' parameters are deprecated.